### PR TITLE
correct error in clear method

### DIFF
--- a/PicoAutonomousRobotics.py
+++ b/PicoAutonomousRobotics.py
@@ -156,7 +156,7 @@ class KitronikPicoRobotBuggy:
             brightAdjustedLEDs[i] = (g<<16) + (r<<8) + b
         self.ZIPLEDs.put(brightAdjustedLEDs, 8)
     def clear(self,whichLED):
-        setLED(whichLED,self.BLACK)
+        self.setLED(whichLED,self.BLACK)
         
     #sets the colour of an individual LED. Use show to make change visible
     def setLED(self,whichLED, whichColour):


### PR DESCRIPTION
Hi !
There is a small error in the clear method. It calls the setLED method, but the `self` was absent.
(I saw it when testing it with my kid)
Thanks for the code and the kit
(Question: I started to translate the documentation in french, for my 10-year kid, will you interested?)